### PR TITLE
fix weapon search bugs

### DIFF
--- a/frontend/src/components/common/WeaponSelector.tsx
+++ b/frontend/src/components/common/WeaponSelector.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Card, Select, Space, Row, Col } from 'antd'
 import type { Gun } from '../../api/client'
@@ -27,6 +28,8 @@ export function WeaponSelector({
   filteredGuns,
 }: WeaponSelectorProps) {
   const { t } = useTranslation()
+  const [searchValue, setSearchValue] = useState('')
+  const [dropdownOpen, setDropdownOpen] = useState(false)
   return (
     <Card title={<span style={{ userSelect: 'none' }}>{t('sidebar.select_weapon')}</span>} size="small">
       <Space direction="vertical" style={{ width: '100%' }}>
@@ -56,7 +59,16 @@ export function WeaponSelector({
           showSearch
           style={{ width: '100%' }}
           value={selectedGunId}
-          onChange={onGunChange}
+          searchValue={searchValue}
+          onSearch={setSearchValue}
+          onDropdownVisibleChange={setDropdownOpen}
+          onChange={(v) => { onGunChange(v); setSearchValue('') }}
+          onKeyDown={(e) => { if (e.key === ' ' && dropdownOpen) setSearchValue(prev => prev + ' ') }}
+          labelRender={(item) => (
+            dropdownOpen && searchValue
+              ? <span style={{ visibility: 'hidden' }}>{item.label}</span>
+              : <span>{item.label}</span>
+          )}
           filterOption={(input, option) => (option?.label ?? '').toLowerCase().includes(input.toLowerCase())}
           options={filteredGuns.map(g => ({ value: g.id, label: g.name }))}
           optionRender={(option) => {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -53,6 +53,10 @@
   --scrollbar-track: rgba(0, 0, 0, 0.35);
 }
 
+input, textarea, button, select {
+  font-family: inherit;
+}
+
 html, body {
   margin: 0;
   min-width: 320px;


### PR DESCRIPTION
fixed weapon search to accept spaces, and remove the placeholder text when the user inputs anything into the search so it doesnt get overlayed ontop, and also use the default site font instead of arial🤮

<img width="543" height="341" alt="1" src="https://github.com/user-attachments/assets/247a2d96-1f3c-46b6-8209-66aa8b740246" />
<img width="542" height="286" alt="2" src="https://github.com/user-attachments/assets/a41e43de-cbf2-4d71-8e83-12ebd95646cf" />

the root cause was that `@rc-component/select` calls `event.preventDefault()` on every space keypress to prevent page scroll, which also blocks the character from reaching the input. also browser default styles don't inherit `font-family` onto `<input>` elements

Fix: controlled `searchValue` + manual space append in `onKeyDown` to bypass the library interception, `labelRender` hides the selected label when typing to prevent text overlap, also made `font-family: inherit` on `input, textarea, button, select` in global CSS.

ong frfr