### PR TITLE
fix: upgrade marked to 18.0.2 (CVE-2026-41680)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,7 +17,7 @@
         "i18next-browser-languagedetector": "^8.2.0",
         "i18next-http-backend": "^3.0.2",
         "lz-string": "^1.5.0",
-        "marked": "^18.0.0",
+        "marked": "^18.0.2",
         "minizinc": "^4.4.5",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -4100,9 +4100,10 @@
       }
     },
     "node_modules/marked": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.0.tgz",
-      "integrity": "sha512-2e7Qiv/HJSXj8rDEpgTvGKsP8yYtI9xXHKDnrftrmnrJPaFNM7VRb2YCzWaX4BP1iCJ/XPduzDJZMFoqTCcIMA==",
+      "version": "18.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.2.tgz",
+      "integrity": "sha512-NsmlUYBS/Zg57rgDWMYdnre6OTj4e+qq/JS2ot3KrYLSoHLw+sDu0Nm1ZGpRgYAq6c+b1ekaY5NzVchMCQnzcg==",
+      "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,7 @@
     "i18next-browser-languagedetector": "^8.2.0",
     "i18next-http-backend": "^3.0.2",
     "lz-string": "^1.5.0",
-    "marked": "^18.0.0",
+    "marked": "^18.0.2",
     "minizinc": "^4.4.5",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",


### PR DESCRIPTION
## Summary
Upgrade marked from 18.0.0 to 18.0.2 to fix CVE-2026-41680.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2026-41680 |
| **Severity** | HIGH |
| **Scanner** | trivy |
| **Rule** | `CVE-2026-41680` |
| **File** | `frontend/package-lock.json` (dependency: `marked`) |
| **Assessment** | Likely exploitable |

**Description**: marked: Marked: Denial of Service via specific input sequence

## Evidence

**Scanner confirmation**: trivy rule `CVE-2026-41680` flagged this pattern.

## Changes
- `frontend/package.json`
- `frontend/package-lock.json`

## Behavior Preservation
The change is scoped to 2 files on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
